### PR TITLE
Fix "handleBack" Prop Injection Naming

### DIFF
--- a/src/views/CardSceneView.js
+++ b/src/views/CardSceneView.js
@@ -46,7 +46,7 @@ export default class SceneView extends React.PureComponent<Props> {
         routeKey={scene.route.key}
         handleNavigate={this.props.handleNavigate}
         trackPage={data => this._trackState(scene.route, data)}
-        handleBack={this.props.handleBackAction}
+        handleBack={this.props.handleBack}
         isLeftSplitPaneComponent={this.props.isLeftSplitPaneComponent}
         isActiveRoute={isActiveRoute}
         isTopScreen={scene.isActive}


### PR DESCRIPTION
This PR fixes a naming issue where our components' `handleBack` prop was undefined.

Verified that components are now able to navigate back when the `this.props.handleBack` function is called.

@sdg9 
  