### PR TITLE
Make sure that split pane animation will be using Native driver.

### DIFF
--- a/src/views/CardStack/CardStackTransitioner.js
+++ b/src/views/CardStack/CardStackTransitioner.js
@@ -58,6 +58,7 @@ class CardStackTransitioner extends React.Component<Props> {
       animation = () => ({
         timing: Animated.timing,
         duration: 0,
+        useNativeDriver: true,
       });
     }
 


### PR DESCRIPTION
Selecting any options on split pane, we were seeing below warning on the screen.
"Attempting to run JS driven animation on animated node that has been moved to "native" earlier by starting an animation with 'useNativeDriver: true' ".

To fix this added useNativeDriver: true as a prop to animation.
 
@sdg9 @cnow7 