### PR TITLE
Observation/NavBar-Android

### DIFF
--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -143,7 +143,7 @@ class CardStack extends React.Component<Props, State> {
     if (this.props.headerMode) {
       return this.props.headerMode;
     }
-    if (Platform.OS === 'android' || this.props.mode === 'modal') {
+    if (this.props.mode === 'modal') {
       return 'screen';
     }
     return 'float';


### PR DESCRIPTION
Navigation bar is missing on Android app. As per the analysis got to know that header mode should be float to display header.
