### PR TITLE
Custom Flip Transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "format": "eslint --fix .",
     "flow": "flow",
     "flow-check": "flow check --show-all-errors",
-    "precommit": "lint-staged",
     "prepublish": "npm run clean && npm run build"
   },
   "files": [

--- a/src/views/CardSceneView.js
+++ b/src/views/CardSceneView.js
@@ -19,7 +19,6 @@ type Props = {
 };
 
 export default class SceneView extends React.PureComponent<Props> {
-
   constructor(props: DFSCardNavigatorProps) {
     super(props);
     (this: any)._trackState = this._trackState.bind(this);
@@ -27,12 +26,13 @@ export default class SceneView extends React.PureComponent<Props> {
 
   _trackState(route, data) {
     if (!route.trackingPageName) {
-      console.warn(`Attribute \`trackingPageName\` not defined in routes for ${route.routeName}`);
+      console.warn(
+        `Attribute \`trackingPageName\` not defined in routes for ${route.routeName}`
+      );
     } else {
       this.props.trackingActions.trackState(route.trackingPageName, data);
     }
   }
-
 
   render() {
     const { routeProps, component: Component, scene } = this.props;
@@ -41,16 +41,14 @@ export default class SceneView extends React.PureComponent<Props> {
       <Component
         {...routeProps}
         key={scene.key}
-
         // routeKey used for ScreenFocusAware
         routeKey={scene.route.key}
         handleNavigate={this.props.handleNavigate}
         trackPage={data => this._trackState(scene.route, data)}
-        handleBack={this.props.handleBack}
-        isLeftSplitPaneComponent={this.props.isLeftSplitPaneComponent}
+        handleBack={this.props.handleBackAction}
         isActiveRoute={isActiveRoute}
         isTopScreen={scene.isActive}
-        />
-    )
+      />
+    );
   }
 }

--- a/src/views/CardSceneView.js
+++ b/src/views/CardSceneView.js
@@ -45,8 +45,8 @@ export default class SceneView extends React.PureComponent<Props> {
         routeKey={scene.route.key}
         handleNavigate={this.props.handleNavigate}
         trackPage={data => this._trackState(scene.route, data)}
-        isLeftSplitPaneComponent={this.props.isLeftSplitPaneComponent}
         handleBack={this.props.handleBack}
+        isLeftSplitPaneComponent={this.props.isLeftSplitPaneComponent}
         isActiveRoute={isActiveRoute}
         isTopScreen={scene.isActive}
       />

--- a/src/views/CardSceneView.js
+++ b/src/views/CardSceneView.js
@@ -45,7 +45,8 @@ export default class SceneView extends React.PureComponent<Props> {
         routeKey={scene.route.key}
         handleNavigate={this.props.handleNavigate}
         trackPage={data => this._trackState(scene.route, data)}
-        handleBack={this.props.handleBackAction}
+        isLeftSplitPaneComponent={this.props.isLeftSplitPaneComponent}
+        handleBack={this.props.handleBack}
         isActiveRoute={isActiveRoute}
         isTopScreen={scene.isActive}
       />

--- a/src/views/CardStack/Card.js
+++ b/src/views/CardStack/Card.js
@@ -25,7 +25,8 @@ class Card extends React.Component<Props> {
     const { children, pointerEvents, style, scene } = this.props;
     const isTopScreen = scene.isActive;
     const modals = this.props.modals;
-    const isAccessible = (isTopScreen) && (_.size(modals) === 0 || modals === undefined);
+    const isAccessible =
+      isTopScreen && (_.size(modals) === 0 || modals === undefined);
     return (
       <Animated.View
         pointerEvents={pointerEvents}

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -59,6 +59,18 @@ type Props = {
   scenes: Array<NavigationScene>,
   scene: NavigationScene,
   index: number,
+  position: number,
+  // True if FLIP_FORWARD or FLIP_BACKWARD and in progress
+  isFlipTransition: boolean,
+  // True during first half of a flip
+  isFlipFrom: boolean,
+  // True during second half of a flip
+  isFlipTo: boolean,
+  // True when animation is in progress
+  isTransitioning: boolean,
+  statusBarSize: number,
+  openDrawer: Function,
+  handleBackAction: Function,
 };
 
 type State = {

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
+import _ from 'lodash';
 
 import clamp from 'clamp';
 import {
@@ -136,23 +137,63 @@ class CardStack extends React.Component<Props, State> {
   render(): React.Node {
     let floatingHeader = null;
     const headerMode = this._getHeaderMode();
+
+    const {
+      scene,
+      scenes,
+      position,
+      isFlipTransition,
+      isFlipFrom,
+      isFlipTo,
+      isTransitioning,
+    } = this.props;
+
+    const {
+      topVisibleScene,
+      isHideTopScene,
+      nonPurgedScenes,
+    } = processFlipAnimation(
+      scene,
+      scenes,
+      isFlipTransition,
+      isFlipFrom,
+      isFlipTo
+    );
+
     if (headerMode === 'float') {
-      floatingHeader = this._renderHeader(this.props.scene, headerMode);
+      floatingHeader = this._renderHeader(topVisibleScene, headerMode);
     }
-    const { scenes } = this.props;
 
     const containerStyle = [
       styles.container,
       this._getTransitionConfig().containerStyle,
     ];
 
+    const { screenInterpolator } = this._getTransitionConfig(
+      topVisibleScene.route.animateFromBottom
+    );
+    let flipAnimationStyle = {};
+    if (isFlipTransition) {
+      flipAnimationStyle =
+        screenInterpolator && screenInterpolator({ ...this.props });
+    }
+
     return (
-      <View style={containerStyle}>
+      <Animated.View style={[containerStyle, flipAnimationStyle]}>
         <View style={styles.scenes}>
-          {scenes.map((s: *) => this._renderCard(s))}
+          {nonPurgedScenes.map((s: *, idx) => {
+            const isTopScene = s.key === scene.key;
+            const isTopVisibleScene = s.key === topVisibleScene.key;
+            const shouldHide = isHideTopScene && isTopScene;
+            return this._renderCard(s, {
+              isTransitioning,
+              isFlipTransition,
+              shouldHide,
+            });
+          })}
         </View>
         {floatingHeader}
-      </View>
+      </Animated.View>
     );
   }
 
@@ -268,6 +309,42 @@ class CardStack extends React.Component<Props, State> {
         {this._renderInnerScene(SceneComponent, scene)}
       </Card>
     );
+  };
+}
+
+function processFlipAnimation(
+  scene,
+  scenes,
+  isFlipTransition,
+  isFlipFrom,
+  isFlipTo
+) {
+  let nonPurgedScenes = scenes;
+  let topVisibleScene = _.last(scenes);
+
+  let isHideTopScene = false;
+  if (isFlipTransition) {
+    if (isFlipFrom) {
+      // If flip from animation in progress, the top visible scene is actually
+      // the previous route
+      topVisibleScene = _.last(nonPurgedScenes.slice(0, -1));
+      isHideTopScene = true;
+    } else if (isFlipTo) {
+      // Don't draw stale scenes after flip completes, ran into issue where
+      // portal blue on bottom would draw behind bottom of flip and looked
+      // weird
+      nonPurgedScenes = nonPurgedScenes.filter(scene => !scene.route.isStale);
+    }
+  }
+  // Never draw purged scenes, stale routes are purged once animation
+  // completes TODO actually purge these from redux instead, after animation
+  // looks good
+  nonPurgedScenes = nonPurgedScenes.filter(scene => !scene.route.isPurged);
+
+  return {
+    topVisibleScene,
+    isHideTopScene,
+    nonPurgedScenes,
   };
 }
 

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -351,9 +351,7 @@ function processFlipAnimation(
       nonPurgedScenes = nonPurgedScenes.filter(scene => !scene.route.isStale);
     }
   }
-  // Never draw purged scenes, stale routes are purged once animation
-  // completes TODO actually purge these from redux instead, after animation
-  // looks good
+
   nonPurgedScenes = nonPurgedScenes.filter(scene => !scene.route.isPurged);
 
   return {

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -40,7 +40,7 @@ const emptyFunction = () => {};
 const theme = {
   white: '#FFFFFF',
   lightGrey: '#B7B7B7',
-}
+};
 
 type Props = {
   headerMode: HeaderMode,
@@ -61,11 +61,10 @@ type Props = {
 };
 
 type State = {
-  headerHeight: number
-}
+  headerHeight: number,
+};
 
 class CardStack extends React.Component<Props, State> {
-
   _screenDetails: {
     [key: string]: ?NavigationScreenDetails<NavigationStackScreenOptions>,
   } = {};
@@ -97,12 +96,17 @@ class CardStack extends React.Component<Props, State> {
   }
 
   _hasSplitPaneComponent(scene) {
-    return this.props.isMultiPaneEligible === true && scene.route.leftSplitPaneComponent != null;
+    return (
+      this.props.isMultiPaneEligible === true &&
+      scene.route.leftSplitPaneComponent != null
+    );
   }
 
   _renderHeader(scene: NavigationScene, headerMode: HeaderMode): ?React.Node {
     // Caribou Start
-    const accessibilityOption = this.props.hasModal ? 'no-hide-descendants' : 'yes';
+    const accessibilityOption = this.props.hasModal
+      ? 'no-hide-descendants'
+      : 'yes';
     return (
       // $FlowFixMeRN0.51.1
       <this.props.headerComponent
@@ -158,22 +162,31 @@ class CardStack extends React.Component<Props, State> {
     const SplitPaneComponent = route.leftSplitPaneComponent;
     const hasSplitPaneComponent = this._hasSplitPaneComponent(scene);
 
-    const paddingTop = route.hideNavBar || route.noNavBar ? 0 : this.state.headerHeight;
+    const paddingTop =
+      route.hideNavBar || route.noNavBar ? 0 : this.state.headerHeight;
     const isActiveRoute = scene.isActive && !this.props.hasModal;
 
     return (
-      <View style={{ flex: 1, paddingTop, backgroundColor: theme.white }}
-        testID={`Screen_${scene.route.routeName}_${isActiveRoute ? 'IsActive' : 'IsNotActive'}`}
+      <View
+        style={{ flex: 1, paddingTop, backgroundColor: theme.white }}
+        testID={`Screen_${scene.route.routeName}_${isActiveRoute
+          ? 'IsActive'
+          : 'IsNotActive'}`}
       >
         <View style={{ flexDirection: 'row', flex: 1 }}>
-          {
-              hasSplitPaneComponent && SplitPaneComponent &&
-              <View style={{ width: 300, borderRightWidth: 1, borderColor: theme.lightGrey }}>
+          {hasSplitPaneComponent &&
+            SplitPaneComponent && (
+              <View
+                style={{
+                  width: 300,
+                  borderRightWidth: 1,
+                  borderColor: theme.lightGrey,
+                }}
+              >
                 <CardSceneView
                   key={`SPLIT_PANE${route.key}`}
                   routeProps={scene.route}
                   component={SplitPaneComponent}
-
                   scene={scene}
                   handleNavigate={this.props.handleNavigate}
                   handleBack={this.props.handleBackAction}
@@ -182,7 +195,7 @@ class CardStack extends React.Component<Props, State> {
                   isLeftSplitPaneComponent
                 />
               </View>
-          }
+            )}
           <View style={{ flex: 1 }}>
             <CardSceneView
               {...route}
@@ -202,7 +215,7 @@ class CardStack extends React.Component<Props, State> {
     );
   }
 
-  _getTransitionConfig = (isAnimateFromBottom) => {
+  _getTransitionConfig = isAnimateFromBottom => {
     const isModal = this.props.mode === 'modal';
 
     return TransitionConfigs.getTransitionConfig(
@@ -211,13 +224,14 @@ class CardStack extends React.Component<Props, State> {
       {},
       /* $FlowFixMe */
       {},
-      isModal || isAnimateFromBottom,
+      isModal || isAnimateFromBottom
     );
   };
 
   _renderCard = (scene: NavigationScene): React.Node => {
-
-    const { screenInterpolator } = this._getTransitionConfig(scene.route.animateFromBottom);
+    const { screenInterpolator } = this._getTransitionConfig(
+      scene.route.animateFromBottom
+    );
     const style =
       screenInterpolator && screenInterpolator({ ...this.props, scene });
 

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -79,14 +79,14 @@ class CardStack extends React.Component<Props, State> {
     (this: any)._hasSplitPaneComponent = this._hasSplitPaneComponent.bind(this);
   }
 
-  componentWillReceiveProps(props: Props, nextProps: Props) {
-    if (props.statusBarSize !== this.props.statusBarSize) {
+  componentWillReceiveProps(nextProps: Props) {
+    if (nextProps.statusBarSize !== this.props.statusBarSize) {
       this.setState({
         headerHeight: (this.props.isIOS ? 45 : 41) + this.props.statusBarSize,
       });
     }
 
-    props.scenes.forEach((newScene: *) => {
+    nextProps.scenes.forEach((newScene: *) => {
       if (
         this._screenDetails[newScene.key] &&
         this._screenDetails[newScene.key].state !== newScene.route

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -40,6 +40,7 @@ const emptyFunction = () => {};
 const theme = {
   white: '#FFFFFF',
   lightGrey: '#B7B7B7',
+  primaryBlue: '#0074B4',
 };
 
 type Props = {
@@ -168,11 +169,17 @@ class CardStack extends React.Component<Props, State> {
 
     return (
       <View
-        style={{ flex: 1, paddingTop, backgroundColor: theme.white }}
+        style={{ flex: 1, backgroundColor: theme.white }}
         testID={`Screen_${scene.route.routeName}_${isActiveRoute
           ? 'IsActive'
           : 'IsNotActive'}`}
       >
+        <View
+          style={{
+            height: paddingTop,
+            backgroundColor: theme.primaryBlue,
+          }}
+        />
         <View style={{ flexDirection: 'row', flex: 1 }}>
           {hasSplitPaneComponent &&
             SplitPaneComponent && (

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -272,7 +272,7 @@ class CardStack extends React.Component<Props, State> {
     );
   }
 
-  _getTransitionConfig = isAnimateFromBottom => {
+  _getTransitionConfig = (isAnimateFromBottom, isFlipTransition) => {
     const isModal = this.props.mode === 'modal';
 
     return TransitionConfigs.getTransitionConfig(
@@ -281,16 +281,34 @@ class CardStack extends React.Component<Props, State> {
       {},
       /* $FlowFixMe */
       {},
-      isModal || isAnimateFromBottom
+      isModal || isAnimateFromBottom,
+      isFlipTransition
     );
   };
 
-  _renderCard = (scene: NavigationScene): React.Node => {
-    const { screenInterpolator } = this._getTransitionConfig(
-      scene.route.animateFromBottom
-    );
-    const style =
-      screenInterpolator && screenInterpolator({ ...this.props, scene });
+  _renderCard = (
+    scene: NavigationScene,
+    { isFlipTransition, shouldHide }
+  ): React.Node => {
+    const { position } = this.props;
+
+    let individualCardAnimation = null;
+    if (isFlipTransition) {
+      if (shouldHide) {
+        // Hide topmost card for first half of flip transition
+        individualCardAnimation = {
+          opacity: 0,
+        };
+      }
+    } else {
+      // Only apply BAU transitioning style as a non-flip
+      // Quirky behavior seen when incorrectly applied where touchables don't respond
+      const { screenInterpolator } = this._getTransitionConfig(
+        scene.route.animateFromBottom
+      );
+      individualCardAnimation =
+        screenInterpolator && screenInterpolator({ ...this.props, scene });
+    }
 
     const SceneComponent = this.props.router.getComponentForRouteName(
       scene.route.routeName
@@ -300,7 +318,7 @@ class CardStack extends React.Component<Props, State> {
       <Card
         {...this.props}
         key={`card_${scene.key}`}
-        style={[style, this.props.cardStyle]}
+        style={[this.props.cardStyle, individualCardAnimation]}
         scene={scene}
       >
         {this._renderInnerScene(SceneComponent, scene)}

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -183,7 +183,10 @@ class CardStack extends React.Component<Props, State> {
           {nonPurgedScenes.map((s: *, idx) => {
             const isTopScene = s.key === scene.key;
             const isTopVisibleScene = s.key === topVisibleScene.key;
-            const shouldHide = isHideTopScene && isTopScene;
+            const shouldHideFlipTo = isHideTopScene && isTopScene;
+            const shouldHideFlipFrom =
+              !isHideTopScene && isFlipTransition && !isTopScene;
+            const shouldHide = shouldHideFlipTo || shouldHideFlipFrom;
             return this._renderCard(s, {
               isFlipTransition,
               shouldHide,
@@ -349,7 +352,7 @@ function processFlipAnimation(
       // Don't draw stale scenes after flip completes, ran into issue where
       // portal blue on bottom would draw behind bottom of flip and looked
       // weird
-      nonPurgedScenes = nonPurgedScenes.filter(scene => !scene.route.isStale);
+      // nonPurgedScenes = nonPurgedScenes.filter(scene => !scene.route.isStale);
     }
   }
 

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -129,6 +129,7 @@ class CardStack extends React.Component<Props, State> {
         onNavigateBack={this.props.handleBackAction}
         scene={scene}
         mode={headerMode}
+        isFlipTransition={this.props.isFlipTransition}
       />
     );
   }

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -183,10 +183,10 @@ class CardStack extends React.Component<Props, State> {
           {nonPurgedScenes.map((s: *, idx) => {
             const isTopScene = s.key === scene.key;
             const isTopVisibleScene = s.key === topVisibleScene.key;
-            const shouldHideFlipTo = isHideTopScene && isTopScene;
-            const shouldHideFlipFrom =
-              !isHideTopScene && isFlipTransition && !isTopScene;
-            const shouldHide = shouldHideFlipTo || shouldHideFlipFrom;
+            const shouldHideFlipToScene = isHideTopScene && isTopScene;
+            const shouldHideFlipFromScene =
+              !isHideTopScene && !isTopScene && isFlipTransition;
+            const shouldHide = shouldHideFlipToScene || shouldHideFlipFromScene;
             return this._renderCard(s, {
               isFlipTransition,
               shouldHide,

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -60,7 +60,7 @@ type Props = {
   scenes: Array<NavigationScene>,
   scene: NavigationScene,
   index: number,
-  position: number,
+  position: Object, // AnimatedValue
   // True if FLIP_FORWARD or FLIP_BACKWARD and in progress
   isFlipTransition: boolean,
   // True during first half of a flip
@@ -68,7 +68,6 @@ type Props = {
   // True during second half of a flip
   isFlipTo: boolean,
   // True when animation is in progress
-  isTransitioning: boolean,
   statusBarSize: number,
   openDrawer: Function,
   handleBackAction: Function,
@@ -145,7 +144,6 @@ class CardStack extends React.Component<Props, State> {
       isFlipTransition,
       isFlipFrom,
       isFlipTo,
-      isTransitioning,
     } = this.props;
 
     const {
@@ -186,7 +184,6 @@ class CardStack extends React.Component<Props, State> {
             const isTopVisibleScene = s.key === topVisibleScene.key;
             const shouldHide = isHideTopScene && isTopScene;
             return this._renderCard(s, {
-              isTransitioning,
               isFlipTransition,
               shouldHide,
             });

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -348,11 +348,6 @@ function processFlipAnimation(
       // the previous route
       topVisibleScene = _.last(nonPurgedScenes.slice(0, -1));
       isHideTopScene = true;
-    } else if (isFlipTo) {
-      // Don't draw stale scenes after flip completes, ran into issue where
-      // portal blue on bottom would draw behind bottom of flip and looked
-      // weird
-      // nonPurgedScenes = nonPurgedScenes.filter(scene => !scene.route.isStale);
     }
   }
 

--- a/src/views/CardStack/CardStackTransitioner.js
+++ b/src/views/CardStack/CardStackTransitioner.js
@@ -1,10 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
-import {
-  Animated,
-  NativeModules
-} from 'react-native';
+import { Animated, NativeModules } from 'react-native';
 
 import CardStack from './CardStack';
 import CardStackStyleInterpolator from './CardStackStyleInterpolator';
@@ -51,8 +48,10 @@ class CardStackTransitioner extends React.Component<Props> {
     const routes = this.props.navigation.state.routes;
     const currentScene = routes[routes.length - 1] || {};
     const previousScene = routes[routes.length - 2] || {};
-    const splitPaneToSplitPaneNav = this.props.isMultiPaneEligible
-      && currentScene.leftSplitPaneComponent && previousScene.leftSplitPaneComponent;
+    const splitPaneToSplitPaneNav =
+      this.props.isMultiPaneEligible &&
+      currentScene.leftSplitPaneComponent &&
+      previousScene.leftSplitPaneComponent;
     let animation = this._configureTransition;
     if (splitPaneToSplitPaneNav) {
       animation = () => ({

--- a/src/views/CardStack/CardStackTransitioner.js
+++ b/src/views/CardStack/CardStackTransitioner.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { Animated, NativeModules } from 'react-native';
+import _ from 'lodash';
 
 import CardStack from './CardStack';
 import CardStackStyleInterpolator from './CardStackStyleInterpolator';
@@ -24,6 +25,14 @@ import type {
 const NativeAnimatedModule =
   NativeModules && NativeModules.NativeAnimatedModule;
 
+const FLIP_FORWARD = 'FLIP_FORWARD';
+const FLIP_BACKWARD = 'FLIP_BACKWARD';
+
+const isFlipTransition = route =>
+  !route.hasTransitionCompleted &&
+  (route.customTransition === FLIP_FORWARD ||
+    route.customTransition === FLIP_BACKWARD);
+
 type Props = {
   headerMode: HeaderMode,
   mode: 'card' | 'modal',
@@ -35,19 +44,30 @@ type Props = {
    * Optional custom animation when transitioning between screens.
    */
   transitionConfig?: () => TransitionConfig,
+  isMultiPaneEligible: boolean,
 } & NavigationNavigatorProps<NavigationStackScreenOptions, NavigationState>;
 
-class CardStackTransitioner extends React.Component<Props> {
+type State = {
+  isFlipFrom: boolean,
+  isFlipTo: boolean,
+};
+
+class CardStackTransitioner extends React.Component<Props, State> {
   _render: NavigationSceneRenderer;
 
   static defaultProps = {
     mode: 'card',
   };
 
+  state = {
+    isFlipFrom: false,
+    isFlipTo: false,
+  };
+
   render() {
     const routes = this.props.navigation.state.routes;
-    const currentScene = routes[routes.length - 1] || {};
-    const previousScene = routes[routes.length - 2] || {};
+    const currentScene = _.last(routes);
+    const previousScene = _.last(routes.slice(0, -1));
     const splitPaneToSplitPaneNav =
       this.props.isMultiPaneEligible &&
       currentScene.leftSplitPaneComponent &&
@@ -68,6 +88,25 @@ class CardStackTransitioner extends React.Component<Props> {
         render={this._render}
         onTransitionStart={this.props.onTransitionStart}
         onTransitionEnd={this.props.onTransitionEnd}
+        onFlipStart={() => {
+          this.setState({
+            isFlipFrom: true,
+            isFlipTo: false,
+          });
+        }}
+        onFlipFromComplete={() => {
+          this.setState({
+            isFlipFrom: false,
+            isFlipTo: true,
+          });
+        }}
+        onFlipToComplete={() => {
+          this.setState({
+            isFlipFrom: false,
+            isFlipTo: false,
+          });
+        }}
+        isFlipTransition={isFlipTransition(currentScene)}
       />
     );
   }
@@ -109,6 +148,8 @@ class CardStackTransitioner extends React.Component<Props> {
       cardStyle,
       transitionConfig,
     } = this.props;
+
+    const currentScene = _.last(this.props.navigation.state.routes);
     return (
       <CardStack
         screenProps={screenProps}
@@ -130,6 +171,9 @@ class CardStackTransitioner extends React.Component<Props> {
         handleBackAction={this.props.handleBackAction}
         handleNavigate={this.props.handleNavigate}
         modals={this.props.modals}
+        isFlipTransition={isFlipTransition(currentScene)}
+        isFlipFrom={this.state.isFlipFrom}
+        isFlipTo={this.state.isFlipTo}
       />
     );
   };

--- a/src/views/CardStack/CardStackTransitioner.js
+++ b/src/views/CardStack/CardStackTransitioner.js
@@ -77,7 +77,6 @@ class CardStackTransitioner extends React.Component<Props, State> {
       animation = () => ({
         timing: Animated.timing,
         duration: 0,
-        useNativeDriver: true,
       });
     }
 
@@ -133,8 +132,16 @@ class CardStackTransitioner extends React.Component<Props, State> {
       // Native animation support also depends on the transforms used:
       CardStackStyleInterpolator.canUseNativeDriver()
     ) {
+      // TODO setting useNativeDriver to false as a workaround.
+      // Problem: Page freezes/doesn't respond to touch events when animations
+      // swap between Card and CardStack now that the container view of
+      // CardStack is an Animated.View (so it can do the flip transition)
+      // Example 1 - Login in as SSO clicking a portal tile, logout, try to interact with Login page
+      // Example 2 - Go to forgot password and back from Login, try to interact with Login page
+      // Every time I get 1 to work, 2 breaks, and vice versa. Setting this to false solves both
+
       // Internal undocumented prop
-      transitionSpec.useNativeDriver = true;
+      transitionSpec.useNativeDriver = false;
     }
     return transitionSpec;
   };

--- a/src/views/CardStack/CardStackTransitioner.js
+++ b/src/views/CardStack/CardStackTransitioner.js
@@ -141,7 +141,7 @@ class CardStackTransitioner extends React.Component<Props, State> {
       // Every time I get 1 to work, 2 breaks, and vice versa. Setting this to false solves both
 
       // Internal undocumented prop
-      transitionSpec.useNativeDriver = false;
+      transitionSpec.useNativeDriver = true;
     }
     return transitionSpec;
   };

--- a/src/views/CardStack/CardStackTransitioner.js
+++ b/src/views/CardStack/CardStackTransitioner.js
@@ -141,7 +141,7 @@ class CardStackTransitioner extends React.Component<Props, State> {
       // Every time I get 1 to work, 2 breaks, and vice versa. Setting this to false solves both
 
       // Internal undocumented prop
-      transitionSpec.useNativeDriver = true;
+      transitionSpec.useNativeDriver = false;
     }
     return transitionSpec;
   };

--- a/src/views/ScenesReducer.js
+++ b/src/views/ScenesReducer.js
@@ -73,6 +73,16 @@ function areRoutesShallowEqual(
   return shallowEqual(one, two);
 }
 
+export function reduxToComponentStateHelper(nextState: NavigationState) {
+  return nextState.routes.map((route, index) => ({
+    index,
+    isActive: index === nextState.routes.length - 1,
+    isStale: false,
+    key: SCENE_KEY_PREFIX + route.key,
+    route,
+  }));
+}
+
 export default function ScenesReducer(
   scenes: Array<NavigationScene>,
   nextState: NavigationState,

--- a/src/views/ScenesReducer.js
+++ b/src/views/ScenesReducer.js
@@ -73,16 +73,6 @@ function areRoutesShallowEqual(
   return shallowEqual(one, two);
 }
 
-export function reduxToComponentStateHelper(nextState: NavigationState) {
-  return nextState.routes.map((route, index) => ({
-    index,
-    isActive: index === nextState.routes.length - 1,
-    isStale: false,
-    key: SCENE_KEY_PREFIX + route.key,
-    route,
-  }));
-}
-
 export default function ScenesReducer(
   scenes: Array<NavigationScene>,
   nextState: NavigationState,

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -30,6 +30,9 @@ type Props = {
     transitionProps: NavigationTransitionProps,
     prevTransitionProps: ?NavigationTransitionProps
   ) => React.Node,
+  onFlipStart: Function,
+  onFlipFromComplete: Function,
+  onFlipToComplete: Function,
 };
 
 type State = {
@@ -159,16 +162,16 @@ class Transitioner extends React.Component<Props, State> {
     // update scenes and play the transition
     this._isTransitionRunning = true;
     this.setState(nextState, async () => {
-      // if (nextProps.onTransitionStart) {
-      //   const result = nextProps.onTransitionStart(
-      //     this._transitionProps,
-      //     this._prevTransitionProps
-      //   );
-      //
-      //   if (result instanceof Promise) {
-      //     await result;
-      //   }
-      // }
+      if (nextProps.onTransitionStart) {
+        const result = nextProps.onTransitionStart(
+          this._transitionProps,
+          this._prevTransitionProps
+        );
+
+        if (result instanceof Promise) {
+          await result;
+        }
+      }
       if (this.props.isFlipTransition) {
         const { flipFromAnimation, flipToAnimation } = getFlipAnimations(
           indexHasChanged,
@@ -273,8 +276,7 @@ class Transitioner extends React.Component<Props, State> {
         this._startTransition(
           this._queuedTransition.nextProps,
           this._queuedTransition.nextScenes,
-          this._queuedTransition.indexHasChanged,
-          this._queuedTransition.keyHasChanged
+          this._queuedTransition.indexHasChanged
         );
         this._queuedTransition = null;
       } else {

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -1,12 +1,15 @@
 /* @flow */
 
 import * as React from 'react';
+import _ from 'lodash';
 
 import { Animated, Easing, StyleSheet, View } from 'react-native';
 
 import invariant from '../utils/invariant';
 
-import NavigationScenesReducer from './ScenesReducer';
+import NavigationScenesReducer, {
+  reduxToComponentStateHelper,
+} from './ScenesReducer';
 
 import type {
   NavigationLayout,
@@ -108,24 +111,57 @@ class Transitioner extends React.Component<Props, State> {
       this.props.navigation.state
     );
 
-    if (nextScenes === this.state.scenes) {
+    const noSceneChange = nextScenes === this.state.scenes;
+    if (noSceneChange) {
       return;
     }
 
+    const nextKey = _.last(nextProps.navigation.state.routes).key;
+    const thisKey = _.last(this.props.navigation.state.routes).key;
+    const keyHasChanged = nextKey !== thisKey;
     const indexHasChanged =
       nextProps.navigation.state.index !== this.props.navigation.state.index;
-    if (this._isTransitionRunning) {
-      this._queuedTransition = { nextProps, nextScenes, indexHasChanged };
+
+    const noViewableSceneChange = indexHasChanged && !keyHasChanged;
+
+    if (noViewableSceneChange) {
+      // Remove from the stack without breaking animations or causing unwanted
+      // animation. Transitioner maintains them in component state and must
+      // mirror what is passed from react store
+
+      const nextScenes = reduxToComponentStateHelper(
+        nextProps.navigation.state
+      );
+      this.setState({
+        scenes: nextScenes,
+      });
+
       return;
     }
 
-    this._startTransition(nextProps, nextScenes, indexHasChanged);
+    if (this._isTransitionRunning) {
+      this._queuedTransition = {
+        nextProps,
+        nextScenes,
+        indexHasChanged,
+        keyHasChanged,
+      };
+      return;
+    }
+
+    this._startTransition(
+      nextProps,
+      nextScenes,
+      indexHasChanged,
+      keyHasChanged
+    );
   }
 
   _startTransition(
     nextProps: Props,
     nextScenes: Array<NavigationScene>,
-    indexHasChanged: boolean
+    indexHasChanged: boolean,
+    keyHasChanged: boolean
   ) {
     const nextState = {
       ...this.state,
@@ -155,8 +191,13 @@ class Transitioner extends React.Component<Props, State> {
     const { timing } = transitionSpec;
     delete transitionSpec.timing;
 
-    const toValue = nextProps.navigation.state.index;
-    const positionHasChanged = position.__getValue() !== toValue;
+    let positionHasChanged;
+    if (keyHasChanged) {
+      positionHasChanged = true;
+    } else if (indexHasChanged) {
+      const toValue = nextProps.navigation.state.index;
+      positionHasChanged = position.__getValue() !== toValue;
+    }
 
     // update scenes and play the transition
     this._isTransitionRunning = true;
@@ -275,7 +316,8 @@ class Transitioner extends React.Component<Props, State> {
         this._startTransition(
           this._queuedTransition.nextProps,
           this._queuedTransition.nextScenes,
-          this._queuedTransition.indexHasChanged
+          this._queuedTransition.indexHasChanged,
+          this._queuedTransition.keyHasChanged
         );
         this._queuedTransition = null;
       } else {


### PR DESCRIPTION
* Changing our react-navigation to allow for the custom flip transition which is required from business
@sdg9 Did a lot of changes in this library, so he will have more insight to changes. Commit messages are detailed.

Changes in Card stack include:
* drawing non purged scenes for rendering each card in the card stack
* editing render to know when to hide scenes during flip
* masking white header when flipping by making it primary blue
* procesFlipAnimation method to hide

Changes in CardStackTransitioner include:
* determine if isFlipTranstion Prop
* pass onFlipStart, onFlipFromComplete, onFlipToComplete to Transitioner
* have to set transitionSpec.useNativeDriver = false, because there is a freeze issue with flipping transitions and some screens freeze
* pass isFlipFrom, isFlipTo, is FlipTransition to CardStack

Changes in ScenesReducer include: 
* reduxToComponentStateHelper defined to help sync up react-navigation and caribou

Changes in Transitioner include: 
* noViewableSceneChange logic is added
* start transition
* if we are a flip transition we split the transition into two
* else we go regular default transitions
* define getRegularAnimation and getFlipAnimation to help with transitions




