### PR TITLE
feature/192587 Use nextProps instead of this.props

### DIFF
--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -94,7 +94,7 @@ class CardStack extends React.Component<Props, State> {
   componentWillReceiveProps(nextProps: Props) {
     if (nextProps.statusBarSize !== this.props.statusBarSize) {
       this.setState({
-        headerHeight: (this.props.isIOS ? 45 : 41) + this.props.statusBarSize,
+        headerHeight: (this.props.isIOS ? 45 : 41) + nextProps.statusBarSize,
       });
     }
 


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Explain the **motivation** for making this change. What existing problem does the pull request solve?
- When newProps would come, `CardStack` was making a check to see if the status bar size had changed. If it had however, it was continuing to base it's `headerHeight` state variable off of `this.props.statusBarSize`, and so we will only get the updated status bar size if the status bar size changes again -- which will then cause the one we're using to be out of date.

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise split it.

**Test plan (required)**

- I've been using this between a couple different simulator sizes while developing my iPhone X bar button defect and haven't seen an issue so far between iPhone X, iPad and iPhones. iOS is the only OS that updates the status bar prop after it's been set currently, so Android is unaffected by this change.

@rplankenhorn Here's the change I was talking about, essentially the `state.headerHeight` variable is used to know where to start drawing the current screen, when it isn't updated properly the screens flow underneath the header. If you know of another way to fix this issue I could close this and make a PR in our main branch, but I'm not sure how else we could fix this issue besides finding some way to not change the status bar height (and even then, I think we're just delaying an eventual defect, since this code was supposed to update the header height but never actually does.)

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests and shouldn't add more Flow errors.

**Code formatting**

Look around. Match the style of the rest of the codebase.
